### PR TITLE
force change baudrate to take effect

### DIFF
--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -63,6 +63,7 @@ bool Serial::set_baud_rate(unsigned int baud_rate)
   try
   {
     serial_port_.set_option(serial_port_base::baud_rate(baud_rate_));
+    serial_port_.open(port_);
   }
   catch (boost::system::system_error e)
   {


### PR DESCRIPTION
The way it was done before didn't actually make the baud rate change.  Re-opening the port seems to make it work, however it prints `open: already opened`.  I'm not sure if there is a better way.