### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+---
+Language:        Cpp
+BasedOnStyle:  google
+IndentWidth: 2
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+AlignTrailingComments: true
+PointerAlignment: Right
+UseTab: Never
+AllowShortIfStatementsOnASingleLine: false
+AccessModifierOffset: -2

--- a/examples/serial_loopback.cpp
+++ b/examples/serial_loopback.cpp
@@ -34,8 +34,9 @@
  * @file serial_loopback.cpp
  * @author Daniel Koch <danielpkoch@gmail.com>
  *
- * This example is designed for use with a USB-to-UART adapter with the RX and TX pins connected together (loopback).
- * Sends a series of bytes out and prints them to the console as they are received back.
+ * This example is designed for use with a USB-to-UART adapter with the RX and TX pins connected
+ * together (loopback). Sends a series of bytes out and prints them to the console as they are
+ * received back.
  */
 
 #include <async_comm/serial.h>
@@ -47,7 +48,6 @@
 #include <thread>
 
 #define NUM_BYTES 64
-
 
 /**
  * @brief Callback function for the async_comm library
@@ -64,7 +64,6 @@ void callback(const uint8_t* buf, size_t len)
     std::printf("Received byte: %d\n", buf[i]);
   }
 }
-
 
 int main(int argc, char** argv)
 {

--- a/examples/serial_protocol.cpp
+++ b/examples/serial_protocol.cpp
@@ -34,8 +34,8 @@
  * @file serial_protocol.cpp
  * @author Daniel Koch <danielpkoch@gmail.com>
  *
- * This example implements a simple serial protocol, and tests the async_comm library using that protocol on a serial
- * loopback (USB-to-UART converter with the RX and TX pins connected together).
+ * This example implements a simple serial protocol, and tests the async_comm library using that
+ * protocol on a serial loopback (USB-to-UART converter with the RX and TX pins connected together).
  *
  * The message defined by the serial protocol has the following format:
  *
@@ -47,8 +47,8 @@
  * | `v2`       | uint32_t | 4            | The second data field                                |
  * | CRC        | uint8_t  | 1            | Cyclic redundancy check (CRC) byte                   |
  *
- * The "payload" of the message is the part that contains the actual data, and consists of the `id`, `v1`, and `v2`
- * fields.
+ * The "payload" of the message is the part that contains the actual data, and consists of the `id`,
+ * `v1`, and `v2` fields.
  *
  * The parser is implemented as a finite state machine.
  */
@@ -80,13 +80,13 @@
 #define NUM_START_BITS 1
 #define NUM_STOP_BITS 1
 
-
 /**
  * @brief Recursively update the cyclic redundancy check (CRC)
  *
  * This uses the CRC-8-CCITT polynomial.
  *
- * Source: http://www.nongnu.org/avr-libc/user-manual/group__util__crc.html#gab27eaaef6d7fd096bd7d57bf3f9ba083
+ * Source:
+ * http://www.nongnu.org/avr-libc/user-manual/group__util__crc.html#gab27eaaef6d7fd096bd7d57bf3f9ba083
  *
  * @param inCrc The current CRC value. This should be initialized to 0 before processing first byte.
  * @param inData The byte being processed
@@ -94,14 +94,14 @@
  */
 uint8_t update_crc(uint8_t inCrc, uint8_t inData)
 {
-  uint8_t   i;
-  uint8_t   data;
+  uint8_t i;
+  uint8_t data;
 
   data = inCrc ^ inData;
 
-  for ( i = 0; i < 8; i++ )
+  for (i = 0; i < 8; i++)
   {
-    if (( data & 0x80 ) != 0 )
+    if ((data & 0x80) != 0)
     {
       data <<= 1;
       data ^= 0x07;
@@ -114,7 +114,6 @@ uint8_t update_crc(uint8_t inCrc, uint8_t inData)
   return data;
 }
 
-
 /**
  * @brief Pack message contents into a buffer
  * @param[out] dst Buffer in which to store the message
@@ -122,23 +121,23 @@ uint8_t update_crc(uint8_t inCrc, uint8_t inData)
  * @param[in] v1 First data field of the message
  * @param[in] v2 Second data field of the message
  *
- * @post The specified buffer contains the complete message packet, including start byte and CRC byte
+ * @post The specified buffer contains the complete message packet, including start byte and CRC
+ * byte
  */
 void pack_message(uint8_t* dst, uint32_t id, uint32_t v1, uint32_t v2)
 {
   dst[0] = START_BYTE;
-  memcpy(dst+1, &id, 4);
-  memcpy(dst+5, &v1, 4);
-  memcpy(dst+9, &v2, 4);
+  memcpy(dst + 1, &id, 4);
+  memcpy(dst + 5, &v1, 4);
+  memcpy(dst + 9, &v2, 4);
 
   uint8_t crc = 0;
-  for (size_t i = 0; i < PACKET_LEN-1; i++)
+  for (size_t i = 0; i < PACKET_LEN - 1; i++)
   {
     crc = update_crc(crc, dst[i]);
   }
-  dst[PACKET_LEN-1] = crc;
+  dst[PACKET_LEN - 1] = crc;
 }
-
 
 /**
  * @brief Unpack the contents of a message payload buffer
@@ -150,15 +149,14 @@ void pack_message(uint8_t* dst, uint32_t id, uint32_t v1, uint32_t v2)
  * @pre Buffer contains a valid message payload
  * @post Payload contents have been placed into the specified variables
  */
-void unpack_payload(uint8_t* src, uint32_t *id, uint32_t *v1, uint32_t *v2)
+void unpack_payload(uint8_t* src, uint32_t* id, uint32_t* v1, uint32_t* v2)
 {
   memcpy(id, src, 4);
-  memcpy(v1, src+4, 4);
-  memcpy(v2, src+8, 4);
+  memcpy(v1, src + 4, 4);
+  memcpy(v2, src + 8, 4);
 }
 
-bool received[NUM_MSGS]; //!< Keeps track of which messages we've received back
-
+bool received[NUM_MSGS];  //!< Keeps track of which messages we've received back
 
 /**
  * @brief States for the parser state machine
@@ -170,11 +168,10 @@ enum ParseState
   PARSE_STATE_GOT_PAYLOAD
 };
 
-ParseState parse_state = PARSE_STATE_IDLE; //!< Current state of the parser state machine
-uint8_t receive_buffer[PAYLOAD_LEN]; //!< Buffer for accumulating received payload
+ParseState parse_state = PARSE_STATE_IDLE;  //!< Current state of the parser state machine
+uint8_t receive_buffer[PAYLOAD_LEN];        //!< Buffer for accumulating received payload
 
-int receive_count = 0; //!< Keeps track of how many valid messages have been received
-
+int receive_count = 0;  //!< Keeps track of how many valid messages have been received
 
 /**
  * @brief Passes a received byte through the parser state machine
@@ -187,37 +184,36 @@ void parse_byte(uint8_t byte)
 
   switch (parse_state)
   {
-  case PARSE_STATE_IDLE:
-    if (byte == START_BYTE)
-    {
-      payload_count = 0;
-      crc = 0;
-      crc = update_crc(crc, byte);
+    case PARSE_STATE_IDLE:
+      if (byte == START_BYTE)
+      {
+        payload_count = 0;
+        crc = 0;
+        crc = update_crc(crc, byte);
 
-      parse_state = PARSE_STATE_GOT_START_BYTE;
-    }
-    break;
-  case PARSE_STATE_GOT_START_BYTE:
-    receive_buffer[payload_count] = byte;
-    crc = update_crc(crc, byte);
-    if (++payload_count >= PAYLOAD_LEN)
-    {
-      parse_state = PARSE_STATE_GOT_PAYLOAD;
-    }
-    break;
-  case PARSE_STATE_GOT_PAYLOAD:
-    if (byte == crc)
-    {
-      uint32_t id, v1, v2;
-      unpack_payload(receive_buffer, &id, &v1, &v2);
-      received[id] = true;
-      receive_count++;
-    } // otherwise ignore it
-    parse_state = PARSE_STATE_IDLE;
-    break;
+        parse_state = PARSE_STATE_GOT_START_BYTE;
+      }
+      break;
+    case PARSE_STATE_GOT_START_BYTE:
+      receive_buffer[payload_count] = byte;
+      crc = update_crc(crc, byte);
+      if (++payload_count >= PAYLOAD_LEN)
+      {
+        parse_state = PARSE_STATE_GOT_PAYLOAD;
+      }
+      break;
+    case PARSE_STATE_GOT_PAYLOAD:
+      if (byte == crc)
+      {
+        uint32_t id, v1, v2;
+        unpack_payload(receive_buffer, &id, &v1, &v2);
+        received[id] = true;
+        receive_count++;
+      }  // otherwise ignore it
+      parse_state = PARSE_STATE_IDLE;
+      break;
   }
 }
-
 
 /**
  * @brief Callback function for the async_comm library
@@ -234,7 +230,6 @@ void callback(const uint8_t* buf, size_t len)
     parse_byte(buf[i]);
   }
 }
-
 
 int main(int argc, char** argv)
 {
@@ -270,13 +265,14 @@ int main(int argc, char** argv)
   uint8_t buffer[PACKET_LEN];
   for (uint32_t i = 0; i < NUM_MSGS; i++)
   {
-    pack_message(buffer, i, i*2, i*4);
+    pack_message(buffer, i, i * 2, i * 4);
     serial.send_bytes(buffer, PACKET_LEN);
   }
   auto finish_write = std::chrono::high_resolution_clock::now();
 
   // wait to receive all messages
-  while (receive_count < NUM_MSGS);
+  while (receive_count < NUM_MSGS)
+    ;
 
   auto finish_read = std::chrono::high_resolution_clock::now();
 
@@ -306,8 +302,8 @@ int main(int argc, char** argv)
   std::printf("Elapsed read time: %fms\n", read_time.count());
 
   int num_bytes = NUM_MSGS * PACKET_LEN;
-  double expected_time = num_bytes * (8 + NUM_START_BITS + NUM_STOP_BITS) / (double) BAUD_RATE;
-  std::printf("Expected read time: %fms\n", expected_time*1e3);
+  double expected_time = num_bytes * (8 + NUM_START_BITS + NUM_STOP_BITS) / (double)BAUD_RATE;
+  std::printf("Expected read time: %fms\n", expected_time * 1e3);
   std::printf("Total: %d bytes\n", num_bytes);
 
   return 0;

--- a/examples/udp_hello_world.cpp
+++ b/examples/udp_hello_world.cpp
@@ -34,8 +34,8 @@
  * @file udp_hello_world.cpp
  * @author Daniel Koch <danielpkoch@gmail.com>
  *
- * This example opens two UDP objects listening on different ports on the local host, and then uses each to send a
- * simple "hello world" message to the other.
+ * This example opens two UDP objects listening on different ports on the local host, and then uses
+ * each to send a simple "hello world" message to the other.
  */
 
 #include <async_comm/udp.h>
@@ -47,7 +47,6 @@
 #include <chrono>
 #include <thread>
 #include <vector>
-
 
 /**
  * @brief Callback function for the async_comm library
@@ -64,7 +63,6 @@ void callback(const uint8_t* buf, size_t len)
     std::cout << buf[i];
   }
 }
-
 
 int main()
 {
@@ -83,7 +81,7 @@ int main()
 
   // send message one direction
   char message1[] = "hello world 1!";
-  udp2.send_bytes((uint8_t*) message1, std::strlen(message1));
+  udp2.send_bytes((uint8_t*)message1, std::strlen(message1));
 
   // wait for all bytes to be received
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -91,7 +89,7 @@ int main()
 
   // send message the other direction
   char message2[] = "hello world 2!";
-  udp1.send_bytes((uint8_t*) message2, std::strlen(message2));
+  udp1.send_bytes((uint8_t*)message2, std::strlen(message2));
 
   // wait for all bytes to be received
   std::this_thread::sleep_for(std::chrono::milliseconds(500));

--- a/include/async_comm/comm.h
+++ b/include/async_comm/comm.h
@@ -49,16 +49,15 @@
 #include <boost/function.hpp>
 
 #ifndef ASYNC_COMM_READ_BUFFER_SIZE
-  #define ASYNC_COMM_READ_BUFFER_SIZE 1024
+#define ASYNC_COMM_READ_BUFFER_SIZE 1024
 #endif
 
 #ifndef ASYNC_COMM_WRITE_BUFFER_SIZE
-  #define ASYNC_COMM_WRITE_BUFFER_SIZE 1024
+#define ASYNC_COMM_WRITE_BUFFER_SIZE 1024
 #endif
 
 namespace async_comm
 {
-
 /**
  * @class Comm
  * @brief Abstract base class for an asynchronous communication port
@@ -85,7 +84,7 @@ public:
    * @param src Address of the buffer
    * @param len Number of bytes to send
    */
-  void send_bytes(const uint8_t * src, size_t len);
+  void send_bytes(const uint8_t* src, size_t len);
 
   /**
    * @brief Send a single byte over the port
@@ -96,32 +95,32 @@ public:
   /**
    * @brief Register a callback function for when bytes are received on the port
    *
-   * The callback function needs to accept two parameters. The first is of type `const uint8_t*`, and is a constant
-   * pointer to the data buffer. The second is of type `size_t`, and specifies the number of bytes available in the
-   * buffer.
+   * The callback function needs to accept two parameters. The first is of type `const uint8_t*`,
+   * and is a constant pointer to the data buffer. The second is of type `size_t`, and specifies the
+   * number of bytes available in the buffer.
    *
-   * @warning The data buffer passed to the callback function will be invalid after the callback function exits. If you
-   * want to store the data for later processing, you must copy the data to a new buffer rather than storing the
-   * pointer to the buffer.
+   * @warning The data buffer passed to the callback function will be invalid after the callback
+   * function exits. If you want to store the data for later processing, you must copy the data to a
+   * new buffer rather than storing the pointer to the buffer.
    *
    * @param fun Function to call when bytes are received
    */
   void register_receive_callback(std::function<void(const uint8_t*, size_t)> fun);
 
 protected:
-
   virtual bool is_open() = 0;
   virtual bool do_init() = 0;
   virtual void do_close() = 0;
-  virtual void do_async_read(const boost::asio::mutable_buffers_1 &buffer,
-                             boost::function<void(const boost::system::error_code&, size_t)> handler) = 0;
-  virtual void do_async_write(const boost::asio::const_buffers_1 &buffer,
-                              boost::function<void(const boost::system::error_code&, size_t)> handler) = 0;
+  virtual void do_async_read(
+      const boost::asio::mutable_buffers_1& buffer,
+      boost::function<void(const boost::system::error_code&, size_t)> handler) = 0;
+  virtual void do_async_write(
+      const boost::asio::const_buffers_1& buffer,
+      boost::function<void(const boost::system::error_code&, size_t)> handler) = 0;
 
   boost::asio::io_service io_service_;
 
 private:
-
   struct WriteBuffer
   {
     uint8_t data[ASYNC_COMM_WRITE_BUFFER_SIZE];
@@ -130,13 +129,13 @@ private:
 
     WriteBuffer() : len(0), pos(0) {}
 
-    WriteBuffer(const uint8_t * buf, uint16_t len) : len(len), pos(0)
+    WriteBuffer(const uint8_t* buf, uint16_t len) : len(len), pos(0)
     {
-      assert(len <= ASYNC_COMM_WRITE_BUFFER_SIZE); //! \todo Do something less catastrophic here
+      assert(len <= ASYNC_COMM_WRITE_BUFFER_SIZE);  //! \todo Do something less catastrophic here
       memcpy(data, buf, len);
     }
 
-    const uint8_t * dpos() const { return data + pos; }
+    const uint8_t* dpos() const { return data + pos; }
 
     size_t nbytes() const { return len - pos; }
   };
@@ -158,6 +157,6 @@ private:
   std::function<void(const uint8_t*, size_t)> receive_callback_;
 };
 
-} // namespace async_comm
+}  // namespace async_comm
 
-#endif // ASYNC_COMM_COMM_H
+#endif  // ASYNC_COMM_COMM_H

--- a/include/async_comm/serial.h
+++ b/include/async_comm/serial.h
@@ -47,7 +47,6 @@
 
 namespace async_comm
 {
-
 /**
  * @class Serial
  * @brief Asynchronous communication class for a serial port
@@ -63,7 +62,6 @@ public:
   Serial(std::string port, unsigned int baud_rate);
   ~Serial();
 
-
   /**
    * @brief Set serial port baud rate
    * @param baud_rate The baud rate for the serial port (e.g. 115200)
@@ -75,10 +73,12 @@ private:
   bool is_open() override;
   bool do_init() override;
   void do_close() override;
-  void do_async_read(const boost::asio::mutable_buffers_1 &buffer,
-                     boost::function<void(const boost::system::error_code&, size_t)> handler) override;
-  void do_async_write(const boost::asio::const_buffers_1 &buffer,
-                      boost::function<void(const boost::system::error_code&, size_t)> handler) override;
+  void do_async_read(
+      const boost::asio::mutable_buffers_1 &buffer,
+      boost::function<void(const boost::system::error_code &, size_t)> handler) override;
+  void do_async_write(
+      const boost::asio::const_buffers_1 &buffer,
+      boost::function<void(const boost::system::error_code &, size_t)> handler) override;
 
   std::string port_;
   unsigned int baud_rate_;
@@ -86,6 +86,6 @@ private:
   boost::asio::serial_port serial_port_;
 };
 
-} // namespace async_comm
+}  // namespace async_comm
 
-#endif // ASYNC_COMM_SERIAL_H
+#endif  // ASYNC_COMM_SERIAL_H

--- a/include/async_comm/udp.h
+++ b/include/async_comm/udp.h
@@ -47,7 +47,6 @@
 
 namespace async_comm
 {
-
 /**
  * @class UDP
  * @brief Asynchronous communication class for a UDP socket
@@ -75,10 +74,12 @@ private:
   bool is_open() override;
   bool do_init() override;
   void do_close() override;
-  void do_async_read(const boost::asio::mutable_buffers_1 &buffer,
-                     boost::function<void(const boost::system::error_code&, size_t)> handler) override;
-  void do_async_write(const boost::asio::const_buffers_1 &buffer,
-                      boost::function<void(const boost::system::error_code&, size_t)> handler) override;
+  void do_async_read(
+      const boost::asio::mutable_buffers_1 &buffer,
+      boost::function<void(const boost::system::error_code &, size_t)> handler) override;
+  void do_async_write(
+      const boost::asio::const_buffers_1 &buffer,
+      boost::function<void(const boost::system::error_code &, size_t)> handler) override;
 
   std::string bind_host_;
   uint16_t bind_port_;
@@ -91,6 +92,6 @@ private:
   boost::asio::ip::udp::endpoint remote_endpoint_;
 };
 
-} // namespace async_comm
+}  // namespace async_comm
 
-#endif // ASYNC_COMM_UDP_H
+#endif  // ASYNC_COMM_UDP_H

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -37,21 +37,14 @@
 
 #include <async_comm/comm.h>
 
-#include <iostream>
 #include <boost/bind.hpp>
+#include <iostream>
 
 namespace async_comm
 {
+Comm::Comm() : io_service_(), write_in_progress_(false) {}
 
-Comm::Comm() :
-  io_service_(),
-  write_in_progress_(false)
-{
-}
-
-Comm::~Comm()
-{
-}
+Comm::~Comm() {}
 
 bool Comm::init()
 {
@@ -93,19 +86,18 @@ void Comm::send_bytes(const uint8_t *src, size_t len)
   async_write(true);
 }
 
-void Comm::register_receive_callback(std::function<void(const uint8_t*, size_t)> fun)
+void Comm::register_receive_callback(std::function<void(const uint8_t *, size_t)> fun)
 {
   receive_callback_ = fun;
 }
 
 void Comm::async_read()
 {
-  if (!is_open()) return;
+  if (!is_open())
+    return;
 
   do_async_read(boost::asio::buffer(read_buffer_, ASYNC_COMM_READ_BUFFER_SIZE),
-                boost::bind(&Comm::async_read_end,
-                            this,
-                            boost::asio::placeholders::error,
+                boost::bind(&Comm::async_read_end, this, boost::asio::placeholders::error,
                             boost::asio::placeholders::bytes_transferred));
 }
 
@@ -135,9 +127,7 @@ void Comm::async_write(bool check_write_state)
   write_in_progress_ = true;
   WriteBuffer *buffer = write_queue_.front();
   do_async_write(boost::asio::buffer(buffer->dpos(), buffer->nbytes()),
-                 boost::bind(&Comm::async_write_end,
-                             this,
-                             boost::asio::placeholders::error,
+                 boost::bind(&Comm::async_write_end, this, boost::asio::placeholders::error,
                              boost::asio::placeholders::bytes_transferred));
 }
 
@@ -171,4 +161,4 @@ void Comm::async_write_end(const boost::system::error_code &error, size_t bytes_
     async_write(false);
 }
 
-} // namespace async_comm
+}  // namespace async_comm

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -37,25 +37,18 @@
 
 #include <async_comm/serial.h>
 
-#include<iostream>
+#include <iostream>
 
 using boost::asio::serial_port_base;
 
 namespace async_comm
 {
-
-Serial::Serial(std::string port, unsigned int baud_rate) :
-  Comm(),
-  port_(port),
-  baud_rate_(baud_rate),
-  serial_port_(io_service_)
+Serial::Serial(std::string port, unsigned int baud_rate)
+    : Comm(), port_(port), baud_rate_(baud_rate), serial_port_(io_service_)
 {
 }
 
-Serial::~Serial()
-{
-  do_close();
-}
+Serial::~Serial() { do_close(); }
 
 bool Serial::set_baud_rate(unsigned int baud_rate)
 {
@@ -74,10 +67,7 @@ bool Serial::set_baud_rate(unsigned int baud_rate)
   return true;
 }
 
-bool Serial::is_open()
-{
-  return serial_port_.is_open();
-}
+bool Serial::is_open() { return serial_port_.is_open(); }
 
 bool Serial::do_init()
 {
@@ -99,21 +89,19 @@ bool Serial::do_init()
   return true;
 }
 
-void Serial::do_close()
-{
-  serial_port_.close();
-}
+void Serial::do_close() { serial_port_.close(); }
 
 void Serial::do_async_read(const boost::asio::mutable_buffers_1 &buffer,
-                           boost::function<void (const boost::system::error_code&, size_t)> handler)
+                           boost::function<void(const boost::system::error_code &, size_t)> handler)
 {
   serial_port_.async_read_some(buffer, handler);
 }
 
-void Serial::do_async_write(const boost::asio::const_buffers_1 &buffer,
-                            boost::function<void (const boost::system::error_code&, size_t)> handler)
+void Serial::do_async_write(
+    const boost::asio::const_buffers_1 &buffer,
+    boost::function<void(const boost::system::error_code &, size_t)> handler)
 {
   serial_port_.async_write_some(buffer, handler);
 }
 
-} // namespace async_comm
+}  // namespace async_comm

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -63,6 +63,7 @@ bool Serial::set_baud_rate(unsigned int baud_rate)
   try
   {
     serial_port_.set_option(serial_port_base::baud_rate(baud_rate_));
+    serial_port_.open(port_);
   }
   catch (boost::system::system_error e)
   {

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -43,27 +43,19 @@ using boost::asio::ip::udp;
 
 namespace async_comm
 {
-
-
-UDP::UDP(std::string bind_host, uint16_t bind_port, std::string remote_host, uint16_t remote_port) :
-  Comm(),
-  bind_host_(bind_host),
-  bind_port_(bind_port),
-  remote_host_(remote_host),
-  remote_port_(remote_port),
-  socket_(io_service_)
+UDP::UDP(std::string bind_host, uint16_t bind_port, std::string remote_host, uint16_t remote_port)
+    : Comm(),
+      bind_host_(bind_host),
+      bind_port_(bind_port),
+      remote_host_(remote_host),
+      remote_port_(remote_port),
+      socket_(io_service_)
 {
 }
 
-UDP::~UDP()
-{
-  do_close();
-}
+UDP::~UDP() { do_close(); }
 
-bool UDP::is_open()
-{
-  return socket_.is_open();
-}
+bool UDP::is_open() { return socket_.is_open(); }
 
 bool UDP::do_init()
 {
@@ -81,8 +73,8 @@ bool UDP::do_init()
     socket_.bind(bind_endpoint_);
 
     socket_.set_option(udp::socket::reuse_address(true));
-    socket_.set_option(udp::socket::send_buffer_size(ASYNC_COMM_WRITE_BUFFER_SIZE*1024));
-    socket_.set_option(udp::socket::receive_buffer_size(ASYNC_COMM_READ_BUFFER_SIZE*1024));
+    socket_.set_option(udp::socket::send_buffer_size(ASYNC_COMM_WRITE_BUFFER_SIZE * 1024));
+    socket_.set_option(udp::socket::receive_buffer_size(ASYNC_COMM_READ_BUFFER_SIZE * 1024));
   }
   catch (boost::system::system_error e)
   {
@@ -93,21 +85,18 @@ bool UDP::do_init()
   return true;
 }
 
-void UDP::do_close()
-{
-  socket_.close();
-}
+void UDP::do_close() { socket_.close(); }
 
 void UDP::do_async_read(const boost::asio::mutable_buffers_1 &buffer,
-                        boost::function<void(const boost::system::error_code&, size_t)> handler)
+                        boost::function<void(const boost::system::error_code &, size_t)> handler)
 {
   socket_.async_receive_from(buffer, remote_endpoint_, handler);
 }
 
 void UDP::do_async_write(const boost::asio::const_buffers_1 &buffer,
-                         boost::function<void(const boost::system::error_code&, size_t)> handler)
+                         boost::function<void(const boost::system::error_code &, size_t)> handler)
 {
   socket_.async_send_to(buffer, remote_endpoint_, handler);
 }
 
-} // namespace async_comm
+}  // namespace async_comm


### PR DESCRIPTION
I have another change I want to make, but I did it on vscode with automatic clang-formatting, so there are a bunch of whitespace changes.  I'd rather merge this in first, so that my changes actually make sense.

Here is a proposal for the `.clang-format`