### PR TITLE
Remove catkin exec dependency from package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,23 +39,19 @@ if(ASYNC_COMM_BUILD_EXAMPLES)
   target_link_libraries(tcp_client_hello_world ${PROJECT_NAME})
 endif(ASYNC_COMM_BUILD_EXAMPLES)
 
-# install
-set(LIB_DEST lib/${PROJECT_NAME})
-set(INCLUDE_DEST include)
-
 install(TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}-targets
-  ARCHIVE DESTINATION ${LIB_DEST}
-  LIBRARY DESTINATION ${LIB_DEST}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
 )
 install(DIRECTORY include/${PROJECT_NAME}
-  DESTINATION ${INCLUDE_DEST}
+  DESTINATION include
   FILES_MATCHING PATTERN "*.h"
 )
 
 # install CMake package configuration
-install(EXPORT ${PROJECT_NAME}-targets DESTINATION ${LIB_DEST})
-install(FILES ${PROJECT_NAME}-config.cmake DESTINATION ${LIB_DEST})
+install(EXPORT ${PROJECT_NAME}-targets DESTINATION lib/${PROJECT_NAME})
+install(FILES ${PROJECT_NAME}-config.cmake DESTINATION lib/${PROJECT_NAME})
 
 # install package.xml for ROS release
 install(FILES package.xml DESTINATION share/${PROJECT_NAME})

--- a/async_comm-config.cmake
+++ b/async_comm-config.cmake
@@ -1,4 +1,4 @@
 get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include(${SELF_DIR}/async_comm-targets.cmake)
-get_filename_component(aysnc_comm_INCLUDE_DIRS "${SELF_DIR}/../../include/async_comm" ABSOLUTE)
+get_filename_component(async_comm_INCLUDE_DIRS "${SELF_DIR}/../../include/async_comm" ABSOLUTE)
 set(async_comm_LIBRARIES async_comm)

--- a/package.xml
+++ b/package.xml
@@ -10,12 +10,8 @@
   <url type="repository">https://github.com/dpkoch/async_comm</url>
   <url type="bugtracker">https://github.com/dpkoch/async_comm/issues</url>
 
-  <buildtool_depend>cmake</buildtool_depend>
-
   <build_depend>boost</build_depend>
-
   <exec_depend>boost</exec_depend>
-  <exec_depend>catkin</exec_depend>
 
   <doc_depend>doxygen</doc_depend>
 


### PR DESCRIPTION
This small change enables the usage of this library in ROS2 workspaces - ROS2 doesn't use catkin (it was replaced by colcon/ament).

Additionally, the REP 136 only mentions setting the `<export><build_type>` tag and I don't see this library requiring catkin in order to run - so (AFAIK) the dependency tag was extraneous anyway.

---

With this change a custom ROS2 package can simply do
```xml
  <depend>async_comm</depend>
```
in it's `package.json`, and
```cmake
find_package(async_comm REQUIRED)
ament_target_dependencies(target "async_comm")
```
in `CMakeLists.txt`.