### PR TITLE
Revert deleting <buildtool_depend>cmake</buildtool_depend> from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,8 @@
   <url type="repository">https://github.com/dpkoch/async_comm</url>
   <url type="bugtracker">https://github.com/dpkoch/async_comm/issues</url>
 
+  <buildtool_depend>cmake</buildtool_depend>
+
   <build_depend>boost</build_depend>
   <exec_depend>boost</exec_depend>
 
@@ -19,4 +21,3 @@
     <build_type>cmake</build_type>
   </export>
 </package>
-


### PR DESCRIPTION
#12 seems to have broken things on the ROS buildfarm ([link](https://build.ros.org/job/Mbin_uB64__async_comm__ubuntu_bionic_amd64__binary/9/console)). The error is:

```
11:35:27 dh_auto_configure -- \
11:35:27 	-DCMAKE_INSTALL_PREFIX="/opt/ros/melodic" \
11:35:27 	-DCMAKE_PREFIX_PATH="/opt/ros/melodic"
11:35:27 	install -d obj-x86_64-linux-gnu
11:35:27 	cd obj-x86_64-linux-gnu && cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=None -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_INSTALL_LOCALSTATEDIR=/var -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON -DCMAKE_INSTALL_PREFIX=/opt/ros/melodic -DCMAKE_PREFIX_PATH=/opt/ros/melodic
11:35:27 Can't exec "cmake": No such file or directory at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 356.
11:35:27 dh_auto_configure: cd obj-x86_64-linux-gnu && cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=None -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_INSTALL_LOCALSTATEDIR=/var -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON -DCMAKE_INSTALL_PREFIX=/opt/ros/melodic -DCMAKE_PREFIX_PATH=/opt/ros/melodic failed to execute: No child processes
11:35:27 dh_auto_configure: cd obj-x86_64-linux-gnu && cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=None -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_INSTALL_LOCALSTATEDIR=/var -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON -DCMAKE_INSTALL_PREFIX=/opt/ros/melodic -DCMAKE_PREFIX_PATH=/opt/ros/melodic returned exit code 2
```

Unfortunately the ROS prerelease tests don't catch this, and it doesn't seem easy to reproduce locally. However, it seems like this is probably caused by the

```xml
<buildtool_depend>cmake</buildtool_depend>
```

line being deleted from `package.xml` in #12, causing cmake to be unavailable in this step.

@mjbogusz and @akifh, can you can confirm that this still plays nicely with ROS2 if I add this back in?