### PR TITLE
Portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+if(WIN32)
+  # disable autolinking in boost
+  target_compile_definitions(${PROJECT_NAME} PUBLIC -DBOOST_ALL_NO_LIB)
+endif(WIN32)
 
 # examples
 option(ASYNC_COMM_BUILD_EXAMPLES "Build examples" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ endif (NOT DEFINED CMAKE_BUILD_TYPE)
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(Threads)
 
-add_library(${PROJECT_NAME} SHARED
+option(BUILD_SHARED_LIBS "Build shared library" ON)
+
+add_library(${PROJECT_NAME}
   src/comm.cpp
   src/udp.cpp
   src/serial.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ add_library(${PROJECT_NAME} SHARED
   src/serial.cpp
   src/tcp_client.cpp
 )
-target_include_directories(${PROJECT_NAME} PRIVATE ${Boost_INCLUDE_DIRS})
 target_include_directories(${PROJECT_NAME} PUBLIC
+  ${Boost_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_options(${PROJECT_NAME} PRIVATE -std=c++11)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 # examples


### PR DESCRIPTION
CMake touch ups for portability with MSVC (gross, I know).

- `BOOST_ALL_NO_LIB` fixes weird dynamic vs static linking issues (see [this](https://stackoverflow.com/a/56113457/2392520) and [this](https://stackoverflow.com/a/28902261/2392520))
- By omitting `SHARED` in `add_library`, the user gains control via the [`BUILD_SHARED_LIBS`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) option.
- since `<boost/asio.hpp>` and `<boost/function.hpp>` are included in the public interface, boost includes need to be public, not private (could use PIMPL or maybe forward decl + pointers, but refactor didn't seem worth it)

I wanted the static lib option because building DLLs is a pain. tl;dr GCC exports all symbols by default, MSVC does not. Thought about adding [the infrastructure](https://gernotklingler.com/blog/creating-using-shared-libraries-different-compilers-different-operating-systems/) to handle this, but didn't seem worth it.