### PR TITLE
Satisfy a boost pragma message regarding boost bind placeholders

### DIFF
--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -38,7 +38,7 @@
 #include <async_comm/comm.h>
 
 #include <iostream>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace async_comm
 {


### PR DESCRIPTION
This PR updates `comm.cpp` bind header to `boost/bind/bind.hpp`. This resolves a pragma message from boost when compiling. The `async-comm` library didn't bring the namespace `boost::placeholders` into the global namespace as result further changes were not required.

Refer [here](https://www.boost.org/doc/libs/1_73_0/boost/bind.hpp) for more information.